### PR TITLE
Fix for admin user delete link in the Html UserPresenter.php

### DIFF
--- a/src/services/Html/UserPresenter.php
+++ b/src/services/Html/UserPresenter.php
@@ -91,7 +91,7 @@ class UserPresenter {
 					if (Auth::user()->id !== $row->id)
 					{
 						$btn[] = HTML::link(
-							handles("orchestra/foundation::users/delete/{$row->id}"),
+							handles("orchestra/foundation::users/{$row->id}/delete"),
 							trans('orchestra/foundation::label.delete'),
 							array(
 								'class' => 'btn btn-mini btn-danger',


### PR DESCRIPTION
In the administration panel when you click to delete a user the request sent is users/delete/$id and it should be users/$id/delete

Fixed in this commit.
