### PR TITLE
Only display resources in navigation menus if not hidden

### DIFF
--- a/src/views/resources/list.php
+++ b/src/views/resources/list.php
@@ -1,5 +1,6 @@
 <div class="list-group">
 	<?php foreach ($resources['list'] as $name => $resource) : ?>
+	<?php if(false === value($resource->visible)): continue; endif; ?>
 	<a href="<?php echo resources($name); ?>" 
 		class="list-group-item <?php echo Request::is("*/resources/{$name}*") ? 'active' : ''; ?>">
 		<?php echo $resource->name; ?>


### PR DESCRIPTION
Could probably also handle this in `Orchestra\Foundation\Routing\ResourcesController` by stripping out hidden resources before passing them to the `resources.page` view.

Not sure what your preferred approach is, this seems fine to me though.
