### PR TITLE
Removed a container div inside the resource navbar to fix bootstrap layo...

### DIFF
--- a/src/views/components/navbar.blade.php
+++ b/src/views/components/navbar.blade.php
@@ -5,21 +5,19 @@ use Illuminate\Support\Facades\HTML;
 $attributes = HTML::decorate($navbar->attributes ?: array(), array('class' => 'navbar', 'role' => 'navigation')); ?>
 
 <nav{{ HTML::attributes($attributes) }}>
-	<div class="container">
-		<div class="navbar-header">
-			<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".{{ $navbar->id }}-responsive-collapse">
-				<span class="icon-bar"></span>
-				<span class="icon-bar"></span>
-				<span class="icon-bar"></span>
-			</button>
-			<a href="{{ $navbar->url }}" class="navbar-brand">
-				{{ $navbar->title }}
-			</a>
-		</div>
-		<div class="collapse navbar-collapse {{ $navbar->id }}-responsive-collapse">
-			{{ $navbar->left }}
-			{{ $navbar->right }}
-			{{ $navbar->menu }}
-		</div>
+	<div class="navbar-header">
+		<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".{{ $navbar->id }}-responsive-collapse">
+			<span class="icon-bar"></span>
+			<span class="icon-bar"></span>
+			<span class="icon-bar"></span>
+		</button>
+		<a href="{{ $navbar->url }}" class="navbar-brand">
+			{{ $navbar->title }}
+		</a>
+	</div>
+	<div class="collapse navbar-collapse {{ $navbar->id }}-responsive-collapse">
+		{{ $navbar->left }}
+		{{ $navbar->right }}
+		{{ $navbar->menu }}
 	</div>
 </nav>


### PR DESCRIPTION
I've removed the container div inside the nav element because It was breaking the normal behaviour of bootstrap.
As a proof, if I create an ul with the navbar-right class to add a float right, the ul goes outside of the nav element making it invisible.
