### PR TITLE
show error message when db connection test failed

### DIFF
--- a/src/Orchestra/Foundation/Installation/Requirement.php
+++ b/src/Orchestra/Foundation/Installation/Requirement.php
@@ -69,6 +69,7 @@ class Requirement implements RequirementInterface
             $this->app['db']->connection()->getPdo();
         } catch (PDOException $e) {
             $schema['is'] = false;
+	    $schema['data'] = $e->getMessage();
         }
 
         return array_merge($this->getChecklistSchema(), $schema);

--- a/src/views/install/index/_database.blade.php
+++ b/src/views/install/index/_database.blade.php
@@ -62,6 +62,7 @@
 				<button class="btn btn-danger disabled input-xlarge">
 					<?php echo trans('orchestra/foundation::install.connection.fail'); ?>
 				</button>
+					<?php echo $databaseConnection['data']; ?>
 				<?php endif; ?>
 			</div>
 		</div>


### PR DESCRIPTION
On Ubuntu 12.04 when packages php5-mysql not installed, the db connection status just show the button Failed, without any hint what causing the failure. Took me a while to go through checking username/password, database access before realizing it's the driver that missing.
