### PR TITLE
Added orchestra.validate: user.registration event

### DIFF
--- a/src/Foundation/Validation/Account.php
+++ b/src/Foundation/Validation/Account.php
@@ -31,6 +31,7 @@ class Account extends Validator
     protected function onRegister()
     {
         $this->rules['email'] = array('required', 'email', 'unique:users,email');
+        $this->events[] = 'orchestra.validate: user.registration';
     }
 
     /**


### PR DESCRIPTION
Sometimes we want add some fields on `orchestra.account` form on registration only (Invitation token for example).
But because `orchestra.validate: user.account` is fired on both registration and update, we can't add validation rules on registration only.
Since fields can differ, validation rules should as well.
