### PR TITLE
Updates blade output so code tags are not escaped

### DIFF
--- a/src/views/install/index/_requirement.blade.php
+++ b/src/views/install/index/_requirement.blade.php
@@ -15,11 +15,11 @@
 				@foreach ($checklist as $name => $requirement)
 				<tr>
 					<td>
-						{{ trans("orchestra/foundation::install.system.{$name}.name", $requirement['data']) }}
+						{!! trans("orchestra/foundation::install.system.{$name}.name", $requirement['data']) !!}
 						@if (! ($requirement['is'] === $requirement['should']))
 						<div class="alert{!! true === $requirement['explicit'] ? ' alert-error ' : '' !!}">
-							<strong>{{ trans("orchestra/foundation::install.solution") }}:</strong>
-							{{ trans("orchestra/foundation::install.system.{$name}.solution", $requirement['data']) }}
+							<strong>{!! trans("orchestra/foundation::install.solution") !!}:</strong>
+							{!! trans("orchestra/foundation::install.system.{$name}.solution", $requirement['data']) !!}
 						</div>
 						@endif
 					</td>


### PR DESCRIPTION
Laravel 5.0 uses escaped characters by default. Since code tag is being used in installer requirements view, need to use {!! rather than {{ or {{{ to display the unescaped output.
