### PR TITLE
Remove email_username validation for SMTP Mail setting

### DIFF
--- a/src/Validation/Setting.php
+++ b/src/Validation/Setting.php
@@ -33,7 +33,6 @@ class Setting extends Validator
      */
     protected function onSmtp()
     {
-        $this->rules['email_username'] = ['required'];
         $this->rules['email_host']     = ['required'];
     }
 


### PR DESCRIPTION
Not all SMTP server requires username to connect especially on relay server.